### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,42 @@
-## Installation
+# Installation
+
+## Preparation
+
+Following tools must be installed and available:
+
+* kubectl
+* gcloud
+* helm
+
+Add Helm repository for Jenkins
 
 ```
+helm repo add jenkins https://charts.jenkins.io
+helm repo update
+```
+
+## Infrastructure
+
+```
+# pick a cluster name that is identifiable to you
+CLUSTER_NAME="$(whoami)_cassandra-jenkins"
+# choose your closest (low-carbon) zone
+ZONE="us-central1-c"
+
 # cluster and controller node
-gcloud container clusters create cassius --machine-type e2-standard-8 --disk-type=pd-ssd --num-nodes 1 --node-labels=cassandra.jenkins=controller --autoscaling-profile optimize-utilization --zone us-central1-c
+gcloud container clusters create ${CLUSTER_NAME} --machine-type e2-standard-8 --disk-type=pd-ssd --num-nodes 1 --node-labels=cassandra.jenkins.controller=true --autoscaling-profile optimize-utilization --zone ${ZONE}
 
 # small resource nodes
-gcloud container node-pools create agents-small --cluster cassius --machine-type n2-highcpu-4 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=50 --node-labels=cassandra.jenkins=agent --zone us-central1-c
+gcloud container node-pools create agents-small --cluster ${CLUSTER_NAME} --machine-type n2-highcpu-4 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=50 --node-labels=cassandra.jenkins.agent=true,cassandra.jenkins.agent.small=true --zone ${ZONE}
 
 # medium resource nodes
-gcloud container node-pools create agents-medium --cluster cassius --machine-type n2-highcpu-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=140 --node-labels=cassandra.jenkins=agent --zone us-central1-c
+gcloud container node-pools create agents-medium --cluster ${CLUSTER_NAME} --machine-type n2-highcpu-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=100 --node-labels=cassandra.jenkins.agent=true,cassandra.jenkins.agent.medium=true --zone ${ZONE}
 
 # large resource nodes
-gcloud container node-pools create agents-large --cluster cassius --machine-type n2-highcpu-16 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=140 --node-labels=cassandra.jenkins=agent --zone us-central1-c
+gcloud container node-pools create agents-large --cluster ${CLUSTER_NAME} --machine-type n2-standard-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=160 --node-labels=cassandra.jenkins=cassandra.jenkins.agent=true,cassandra.jenkins.agent.large=true --zone ${ZONE}
 
 # auth (and make default context)
-gcloud container clusters get-credentials cassius --zone us-central1-c
+gcloud container clusters get-credentials cassius --zone ${ZONE}
 
 helm repo add jenkins https://charts.jenkins.io
 helm repo update
@@ -24,10 +46,12 @@ helm upgrade --install -f values.yaml cassius jenkins/jenkins --wait
 kubectl describe svc cassius-jenkins | grep 'LoadBalancer Ingress'
 
 # get the jenkins' password
-kubectl exec --namespace default -it svc/cassius-jenkins -c jenkins -- /bin/cat /run/secrets/additional/chart-admin-password && echo
+kubectl exec -it svc/cassius-jenkins -c jenkins -- /bin/cat /run/secrets/additional/chart-admin-password && echo
 
 # open http://<server_address>:8080
 ```
+
+This leaves the controller running, a single e2-standard-8 instance. All other node-pools downscale to zero.
 
 ### Local-only Access
 
@@ -35,16 +59,16 @@ If you want only local private access to Jenkins, do the following.
 
 Comment these lines before running `heml upgrade …`
 ```
-  serviceType: LoadBalancer
-  ingress:
-    enabled: "true"
+#  serviceType: LoadBalancer
+#  ingress:
+#    enabled: "true"
 ```
 Run the heml upgrade and get the password as usual
 ```
 helm upgrade --install -f values.yaml cassius jenkins/jenkins --wait
 
 # get the jenkins' password
-kubectl exec --namespace default -it svc/cassius-jenkins -c jenkins -- /bin/cat /run/secrets/additional/chart-admin-password && echo
+kubectl exec -it svc/cassius-jenkins -c jenkins -- /bin/cat /run/secrets/additional/chart-admin-password && echo
 
 # port-forward 8080 to the private jenkins
 kubectl port-forward svc/cassius-jenkins 8080:8080

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gcloud container node-pools create agents-small --cluster ${CLUSTER_NAME} --mach
 gcloud container node-pools create agents-medium --cluster ${CLUSTER_NAME} --machine-type n2-highcpu-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=100 --node-labels=cassandra.jenkins.agent=true,cassandra.jenkins.agent.medium=true --zone ${ZONE}
 
 # large resource nodes
-gcloud container node-pools create agents-large --cluster ${CLUSTER_NAME} --machine-type n2-standard-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=160 --node-labels=cassandra.jenkins=cassandra.jenkins.agent=true,cassandra.jenkins.agent.large=true --zone ${ZONE}
+gcloud container node-pools create agents-large --cluster ${CLUSTER_NAME} --machine-type n2-standard-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=160 --node-labels=cassandra.jenkins.agent=true,cassandra.jenkins.agent.large=true --zone ${ZONE}
 
 # auth (and make default context)
 gcloud container clusters get-credentials cassius --zone ${ZONE}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ gcloud container node-pools create agents-medium --cluster ${CLUSTER_NAME} --mac
 gcloud container node-pools create agents-large --cluster ${CLUSTER_NAME} --machine-type n2-standard-8 --disk-type=pd-ssd --enable-autoscaling --spot --num-nodes=0 --min-nodes=0 --max-nodes=160 --node-labels=cassandra.jenkins.agent=true,cassandra.jenkins.agent.large=true --zone ${ZONE}
 
 # auth (and make default context)
-gcloud container clusters get-credentials cassius --zone ${ZONE}
+gcloud container clusters get-credentials ${CLUSTER_NAME} --zone ${ZONE}
 
 # Deploy jenkins
 helm upgrade --install -f values.yaml cassius jenkins/jenkins --wait

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo update
 
 ```
 # pick a cluster name that is identifiable to you
-CLUSTER_NAME="$(whoami)_cassandra-jenkins"
+CLUSTER_NAME="$(whoami)-cassandra-jenkins"
 # choose your closest (low-carbon) zone
 ZONE="us-central1-c"
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ gcloud container node-pools create agents-large --cluster ${CLUSTER_NAME} --mach
 # auth (and make default context)
 gcloud container clusters get-credentials cassius --zone ${ZONE}
 
-helm repo add jenkins https://charts.jenkins.io
-helm repo update
+# Deploy jenkins
 helm upgrade --install -f values.yaml cassius jenkins/jenkins --wait
 
 # get the server's address

--- a/values.yaml
+++ b/values.yaml
@@ -13,10 +13,10 @@ controller:
   resources:
     requests:
       cpu: 4
-      memory: 12G
+      memory: 16G
     limits:
       cpu: 8
-      memory: 16G
+      memory: 20G
   javaOpts: -server -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=40 -Xms8G -Xmx8G
   installPlugins:
     - job-dsl:1.87
@@ -33,7 +33,7 @@ controller:
     - test-stability:2.3
     - copyartifact:722.v0662a_9b_e22a_c
   node-selector:
-    cassandra.jenkins: controller
+    cassandra.jenkins.controller: true
   scriptApproval:
     - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods combinations java.util.Collection"
     - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inspect java.lang.Object"
@@ -76,13 +76,14 @@ controller:
         allowAnonymousRead: false
 agent:
   disableDefaultAgent: true
-  containerCap: 200
+  containerCap: 300
   node-selector:
-    cassandra.jenkins: agent
+    cassandra.jenkins.agent: true
   podTemplates:
     agent-dind-small: |
       - name: agent-dind-small
         label: agent-dind cassandra-small cassandra-amd64-small
+        nodeSelector: 'cassandra.jenkins.agent.small=true'
         activeDeadlineSeconds: '0'
         idleMinutes: 1
         instanceCap: 50
@@ -121,7 +122,7 @@ agent:
             resourceRequestCpu: 1
             resourceLimitCpu: 2
             resourceRequestMemory: 1G
-            resourceLimitMemory: 2G
+            resourceLimitMemory: 1G
             ttyEnabled: 'true'
             workingDir: /home/jenkins/agent
           - name: dind
@@ -145,7 +146,7 @@ agent:
             resourceRequestCpu: 2
             resourceLimitCpu: 4
             resourceRequestMemory: 1G
-            resourceLimitMemory: 1G
+            resourceLimitMemory: 2400M
             ttyEnabled: 'true'
             workingDir: /home/jenkins/agent
         volumes:
@@ -158,6 +159,7 @@ agent:
     agent-dind-medium: |
       - name: agent-dind-medium
         label: agent-dind cassandra-medium cassandra-amd64-medium
+        nodeSelector: 'cassandra.jenkins.agent.medium=true'
         activeDeadlineSeconds: '0'
         idleMinutes: 1
         instanceCap: 140
@@ -197,7 +199,7 @@ agent:
             resourceRequestCpu: 1
             resourceLimitCpu: 3
             resourceRequestMemory: 1G
-            resourceLimitMemory: 2G
+            resourceLimitMemory: 1G
             ttyEnabled: 'false'
             workingDir: /home/jenkins/agent
           - name: dind
@@ -220,8 +222,8 @@ agent:
             privileged: 'true'
             resourceRequestCpu: 2
             resourceLimitCpu: 4
-            resourceRequestMemory: 5G
-            resourceLimitMemory: 6G
+            resourceRequestMemory: 4800M
+            resourceLimitMemory: 5G
             ttyEnabled: 'false'
             workingDir: /home/jenkins/agent
         volumes:
@@ -234,6 +236,7 @@ agent:
     agent-dind-large: |
       - name: agent-dind-large
         label: agent-dind cassandra-amd64-large
+        nodeSelector: 'cassandra.jenkins.agent.large=true'
         activeDeadlineSeconds: '0'
         idleMinutes: 1
         instanceCap: 140
@@ -297,7 +300,7 @@ agent:
             resourceRequestCpu: 6
             resourceLimitCpu: 7
             resourceRequestMemory: 13G
-            resourceLimitMemory: 15G
+            resourceLimitMemory: 16G
             ttyEnabled: 'false'
             workingDir: /home/jenkins/agent
         volumes:


### PR DESCRIPTION
1. Fixes naming issue (only alfanumerics and - are allowed)

```
CLUSTER_NAME="aleks_cassandra-jenkins"
aleksvolchonev@Aleks-Volochnev-WM5W29X32M cassius % ZONE="us-central1-c"
aleksvolchonev@Aleks-Volochnev-WM5W29X32M cassius % gcloud container clusters create ${CLUSTER_NAME} --machine-type e2-standard-8 --disk-type=pd-ssd --num-nodes 1 --node-labels=cassandra.jenkins.controller=true --autoscaling-profile optimize-utilization --zone ${ZONE}
Default change: VPC-native is the default mode during cluster creation for versions greater than 1.21.0-gke.1500. To create advanced routes based clusters, please pass the `--no-enable-ip-alias` flag
Note: Your Pod address range (`--cluster-ipv4-cidr`) can accommodate at most 1008 node(s).

ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Invalid value for field "cluster.name": "aleks_cassandra-jenkins". Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,38}[a-z0-9])?)' (only lowercase alphanumerics and '-' allowed, must start with a letter and end with an alphanumeric, and must be no longer than 40 characters).
```

2. agents-large node-pool creation error (typo)

3. Cleanup (removed redundant step)